### PR TITLE
Update version constraint on oce

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(
         comment=c(ORCID="https://orcid.org/0000-0002-7833-206X")))
 Maintainer: Dan Kelley <dan.kelley@dal.ca>
 Depends: R (>= 3.5.0)
-Suggests: curl, knitr, readr, lubridate, oce (>= 1.2.0), ocedata, marmap (>= 1.0.4), ncdf4, rmarkdown, sf, testthat
+Suggests: curl, knitr, readr, lubridate, oce (>= 1.3.0), ocedata, marmap (>= 1.0.4), ncdf4, rmarkdown, sf, testthat
 Imports: methods, shiny
 BugReports: https://github.com/ArgoCanada/argoFloats/issues
 Description: The 'argoFloats' package supports the analysis of oceanographic data recorded by Argo autonomous drifting profiling floats. Functions are provided to (a) download and cache data files, (b) subset data in various ways, (c) handle quality-control flags and (d) plot the results according to oceanographic conventions. The package is designed to work well with the 'oce' package, providing a wide range of processing capabilities.


### PR DESCRIPTION
This PR fixes #337, adding a version constraint to 'oce' that guarantees that `mapApp()` will work. This is independent of `Remotes:` in the DESCRIPTION but will guarantee that before the next release of oce users will get the GitHub version installed (after it gets removed and oce is updated on CRAN, users will get the updated CRAN version).