### PR TITLE
move progress bar to place where profiles are read in readProfiles()

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -152,13 +152,21 @@ readProfiles <- function(profiles, FUN, destdir=argoDefaultDestdir(), quiet=FALS
                 stop("No valid files found in the \"", destdir, "\" directory. Perhaps getProfiles() was unable to download them, or they were deleted after downloading.")
             fileNames <- gsub(".*/(.*).nc", "\\1.nc", profiles@data$file[!mustSkip])
             fullFileNames <- paste0(destdir, "/", fileNames)
+            
+            n <- length(fullFileNames)
             argoFloatsDebug(debug, "reading", length(fullFileNames), "netcdf files ...\n")
-            res@data$argos <- lapply(fullFileNames, oce::read.argo, debug=debug-1)
-            n <- length(res@data$argos)
-            argoFloatsDebug(debug, "initializing the flag-mapping scheme in the profiles (over-rides oce defaults).\n")
             useProgressBar <- !quiet && interactive()
             if (useProgressBar)
                 pb <- txtProgressBar(0, n, 0, style=3)
+            res@data$argos <- lapply(seq_along(fullFileNames), function(i) {
+                if (useProgressBar)
+                    setTxtProgressBar(pb, i)
+                oce::read.argo(fullFileNames[i], debug=debug-1)
+            })
+            if (useProgressBar)
+                close(pb)
+            
+            argoFloatsDebug(debug, "initializing the flag-mapping scheme in the profiles (over-rides oce defaults).\n")
             for (i in seq_len(n)) {
                 res@data$argos[[i]]@metadata$flagScheme <- list(name="argo",
                                                                 mapping=list(not_assessed=0,
@@ -174,11 +182,7 @@ readProfiles <- function(profiles, FUN, destdir=argoDefaultDestdir(), quiet=FALS
                                                                 default=c(0, 3, 4, 9))
                 res@data$argos[[i]]@processingLog <- oce::processingLogAppend(res@data$argos[[i]]@processingLog,
                                                                               "override existing flagScheme to be mapping=list(not_assessed=0, passed_all_tests=1, probably_good=2, probably_bad=3, bad=4, changed=5, not_used_6=6, not_used_7=7, estimated=8, missing=9)),  default=c(0, 3, 4, 9)")
-                if (useProgressBar)
-                    setTxtProgressBar(pb, i)
             }
-            if (useProgressBar)
-                close(pb)
         } else {
             stop("'profiles' must be a character vector or an object created by getProfiles()")
         }


### PR DESCRIPTION
This is a PR to address #439, where the progress bar wasn't showing up until the very end of `readProfiles()`. The progress bar was being shown along a loop that overrides the flags (almost instantaneous) rather than the one reading the profiles (can take a few minutes). (I'll wait until the checks are done and then ping Dan to review...)