### PR TITLE
Adding age="latest" argument to getProfiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: argoFloats
 Type: Package
 Title: Analysis of Oceanographic Argo Floats
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(
     person(given="Dan", family="Kelley", email="dan.kelley@dal.ca", role=c("aut", "cre", "cph"),
         comment=c(ORCID="https://orcid.org/0000-0001-7808-5911")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,38 +1,44 @@
 # argoFloats (development version)
 
-## argoFloats 1.0.4
+## argoFloats 1.0.5
+
+* Change `getProfiles()` to permit age="latest".
+
+* Change `mapApp()` to allow subset by polygon. 
+
+## argoFloats 1.0.4 (on CRAN)
 
 * Fix image-size declarations in 3 man pages (required by CRAN).
 
-* Change plot() to not show bathymetry by default.
+* Change `plot()` to not show bathymetry by default.
 
-* Improve index[["ID"]] speed by 3X.
+* Improve `index[["ID"]]` speed by 3X.
 
 ## argoFloats 1.0.3 (on CRAN)
 
-* Fix a mapApp() problem with paths that cross the dateline.
-* Fix a mapApp() problem in handling mouse brush events.
+* Fix a `mapApp()` problem with paths that cross the dateline.
+* Fix a `mapApp()` problem in handling mouse brush events.
 
 ## argoFloats 1.0.2 (on CRAN)
 
-* Examples reset par() to its initial state.
+* Examples reset `par()` to its initial state.
 
 ## argoFloats 1.0.1
 
 * DESCRIPTION improved
 * Document return values of all functions
 * Describe base class.
-* plot() resets par() to its initial state before returning.
+* `plot()` resets `par()` to its initial state before returning.
 
 ## argoFloats 1.0.0
 
 * Improve documentation for a CRAN release
-* Remove version number from mapApp()
+* Remove version number from `mapApp()`
 
 ## argoFloats 0.2.0
 
 * Add subset by section
-* Add "traj" and "bio-traj" arguments to getIndex()
+* Add "traj" and "bio-traj" arguments to `getIndex()`
 * Created subtype cycles and trajectories for index type
 * Created map plot for trajectories type
 

--- a/R/download.R
+++ b/R/download.R
@@ -45,23 +45,7 @@ downloadWithRetries <- function(url, destdir, destfile, quiet=FALSE,
 
     destinationInfo <- file.info(destination)
     destinationAge <- (as.integer(Sys.time()) - as.integer(destinationInfo$mtime)) / 86400 # in days
-    if (age == "latest") {
-        f <- list.files(destdir)
-        keep <- which(f %in% destfile)
-        if (length(keep > 1)) {
-            message("it is latest")
-            time <- destinationInfo$ctime
-            # Make times on computer be UTC
-            timeUTC <- lubridate::with_tz(time, "UTC")
-            # Determine if computer time is earlier than date_update
-            # Figure out index from getProfiles FIXME
-            dateUpdate <- index[["date_update"]]
-            # Get file again if it is. Note FALSE means I need to get it again
-            keep2 <- timeUTC < dateUpdate
-            skipDownload <- index[which(keep2 == TRUE)]
-        }
-    }
-        skipDownload <- file.exists(destination) & (destinationAge < age)
+    skipDownload <- file.exists(destination) & (destinationAge < age)
     success[skipDownload] <- TRUE
 
     urlDownload <- url[!skipDownload]

--- a/R/download.R
+++ b/R/download.R
@@ -52,8 +52,7 @@ downloadWithRetries <- function(url, destdir, destfile, quiet=FALSE,
     if (age == "latest") {
         age <- 0
         # FIXME need to define skipDownload here
-        # TO DO: get skipDownload 100% correct in other file,  remove age <- 0 here, ifelse skipDownload
-        message(SKIP, "is SKIP")
+        # TO DO: remove age <- 0 here, ifelse skipDownload
 
     }
 

--- a/R/download.R
+++ b/R/download.R
@@ -47,9 +47,15 @@ downloadWithRetries <- function(url, destdir, destfile, quiet=FALSE,
     destinationAge <- (as.integer(Sys.time()) - as.integer(destinationInfo$mtime)) / 86400 # in days
     skipDownload <- file.exists(destination) & (destinationAge < age)
     success[skipDownload] <- TRUE
-
     urlDownload <- url[!skipDownload]
     destinationDownload <- destination[!skipDownload]
+    if (age == "latest") {
+        age <- 0
+        # FIXME need to define skipDownload here
+        # TO DO: get skipDownload 100% correct in other file,  remove age <- 0 here, ifelse skipDownload
+        message(SKIP, "is SKIP")
+
+    }
 
     for (trial in seq_len(1 + retries)) {
         if (!quiet && (trial > 1))

--- a/R/download.R
+++ b/R/download.R
@@ -45,16 +45,15 @@ downloadWithRetries <- function(url, destdir, destfile, quiet=FALSE,
 
     destinationInfo <- file.info(destination)
     destinationAge <- (as.integer(Sys.time()) - as.integer(destinationInfo$mtime)) / 86400 # in days
-    skipDownload <- file.exists(destination) & (destinationAge < age)
+
+    if (age == "latest") {
+        skipDownload <- skipDownload
+    } else {
+        skipDownload <- file.exists(destination) & (destinationAge < age)
+    }
     success[skipDownload] <- TRUE
     urlDownload <- url[!skipDownload]
     destinationDownload <- destination[!skipDownload]
-    if (age == "latest") {
-        age <- 0
-        # FIXME need to define skipDownload here
-        # TO DO: remove age <- 0 here, ifelse skipDownload
-
-    }
 
     for (trial in seq_len(1 + retries)) {
         if (!quiet && (trial > 1))

--- a/R/download.R
+++ b/R/download.R
@@ -45,7 +45,23 @@ downloadWithRetries <- function(url, destdir, destfile, quiet=FALSE,
 
     destinationInfo <- file.info(destination)
     destinationAge <- (as.integer(Sys.time()) - as.integer(destinationInfo$mtime)) / 86400 # in days
-    skipDownload <- file.exists(destination) & (destinationAge < age)
+    if (age == "latest") {
+        f <- list.files(destdir)
+        keep <- which(f %in% destfile)
+        if (length(keep > 1)) {
+            message("it is latest")
+            time <- destinationInfo$ctime
+            # Make times on computer be UTC
+            timeUTC <- lubridate::with_tz(time, "UTC")
+            # Determine if computer time is earlier than date_update
+            # Figure out index from getProfiles FIXME
+            dateUpdate <- index[["date_update"]]
+            # Get file again if it is. Note FALSE means I need to get it again
+            keep2 <- timeUTC < dateUpdate
+            skipDownload <- index[which(keep2 == TRUE)]
+        }
+    }
+        skipDownload <- file.exists(destination) & (destinationAge < age)
     success[skipDownload] <- TRUE
 
     urlDownload <- url[!skipDownload]

--- a/R/get.R
+++ b/R/get.R
@@ -659,8 +659,31 @@ getProfiles <- function(index, destdir=argoDefaultDestdir(), age=argoDefaultProf
         ## way, so the Ifremer case was rewritten to match the usgodae case.
         urls <- paste0(server, "/dac/", index[["file"]])
         argoFloatsDebug(debug, oce::vectorShow(urls))
-        file <- downloadWithRetries(urls, destdir=destdir, destfile=basename(urls),
-                                    quiet=quiet, age=age, async=TRUE, debug=debug-1)
+        if (age == "latest") {
+            fileNames <- gsub("^.*[/\\\\]([A-Z]*[0-9]*_[0-9]{3,4}[D]{0,1}\\.nc)$", "\\1", index@data$index$file, perl=TRUE) # files of index
+            f <- list.files(destdir) # files in directory
+            path <- paste0(destdir, "/",f)
+            # First, keep files that don't exist
+            download1 <- which(!(fileNames %in% f)) 
+            # Now keep any that do exist, but are out of date
+            if (length(f) > 0) {
+                keep <- which(f %in% fileNames)
+                info <- lapply(path[keep], file.info)
+                time <- do.call(c, lapply(info, function(x) x$ctime))
+                # Make times on computer be UTC
+                timeUTC <- lubridate::with_tz(time, "UTC")
+                # Determine if computer time is earlier than date_update
+                dateUpdate <- index[["date_update"]]
+                # Get file again if it is. Note FALSE means I need to get it again
+                download2 <- which(timeUTC < dateUpdate)
+                file <- c(path[download1], path[download2])
+            } else {
+                file <- path[download1]
+            }
+        } else {
+            file <- downloadWithRetries(urls, destdir=destdir, destfile=basename(urls),
+                quiet=quiet, age=age, async=TRUE, debug=debug-1)
+        }
     }
     res@metadata$destdir <- destdir
     res@data$url <- urls

--- a/R/get.R
+++ b/R/get.R
@@ -582,9 +582,9 @@ getIndex <- function(filename="core",
 #' If the file to be downloaded from the server already exists locally,
 #' and was created is less than age days in the past, it will not be downloaded.
 #' The default is one year. Setting age=0 will force a download.
-#' Option 2) "latest" if the file doesn't exist or the time it was
-#' created is older than the date_update in the index file, it will be
-#' downloaded. Otherwise it will not.
+#' Option 2) "latest" meaning the file will only be downloaded if
+#' A) the file doesn't exist or B) the file does exist and the time
+#' it was created is older than the date_update in the index file
 #'
 #' @template retries
 #'

--- a/R/get.R
+++ b/R/get.R
@@ -578,7 +578,13 @@ getIndex <- function(filename="core",
 #'
 #' @template destdir
 #'
-#' @template age
+#' @param age Option 1) a numerical value indicating a time interval, in days.
+#' If the file to be downloaded from the server already exists locally,
+#' and was created is less than age days in the past, it will not be downloaded.
+#' The default is one year. Setting age=0 will force a download.
+#' Option 2) "latest" if the file doesn't exist or the time it was
+#' created is older than the date_update in the index file, it will be
+#' downloaded. Otherwise it will not.
 #'
 #' @template retries
 #'

--- a/R/get.R
+++ b/R/get.R
@@ -664,7 +664,7 @@ getProfiles <- function(index, destdir=argoDefaultDestdir(), age=argoDefaultProf
             f <- list.files(destdir) # files in directory
             path <- paste0(destdir, "/",f)
             # First, keep files that don't exist
-            download1 <- which(!(fileNames %in% f)) 
+            download1 <- which(!(fileNames %in% f))
             # Now keep any that do exist, but are out of date
             if (length(f) > 0) {
                 keep <- which(f %in% fileNames)

--- a/R/get.R
+++ b/R/get.R
@@ -675,17 +675,15 @@ getProfiles <- function(index, destdir=argoDefaultDestdir(), age=argoDefaultProf
             dateUpdate <- index[["date_update"]][keep]
             # Get file again if it is
             #download2 <- which(!(timeUTC < dateUpdate)) # FIXME can turn this to ! if check to work
-            download2 <- which(timeUTC < dateUpdate) # FIXME can turn this to ! if check to work
-            argoFloatsDebug(debug, "Files numbered" ,download1, " did not exist and are not skipped. \n")
-            argoFloatsDebug(debug, "Files numbered" ,download2, " did exist and had date older than the date_update. They are not skipped. \n")
-           # message(download1, "is download 1 meaning it didn't exist and we CANT SKIP IT")
-           # message(download2, "is download 2 meaning it did exist but the date was older than updated and we CANT SKIP IT")
-            sd2 <- downloadWithRetries(urls, destdir=destdir, destfile=basename(urls), quiet=quiet, age="latest", async=TRUE, debug=debug-1)
+            download2 <- which(timeUTC < dateUpdate)
+            argoFloatsDebug(debug, "In age= ", age, ", files numbered" ,download1, " did not exist and are not skipped during downloading. \n")
+            argoFloatsDebug(debug, "In age= ", age, ", files numbered" ,download2, " did exist and had date older than the date_update. They are not skipped during downloading. \n")
             SKIP1 <- which(!(seq_along(fileNames) %in% download1))
             SKIP2 <- which(!(seq_along(fileNames[keep]) %in% download2))
-            skipDownload <<- unique(c(SKIP1, SKIP2))
+            skipDownload <<- rep(FALSE, length(fileNames))
+            skipDownload[SKIP1] <<- TRUE
+            skipDownload[SKIP2] <<- TRUE
             argoFloatsDebug(debug, "Files numbered ", skipDownload, " are being skipped during download. \n")
-
         }
         file <- downloadWithRetries(urls, destdir=destdir, destfile=basename(urls),
             quiet=quiet, age=age, async=TRUE, debug=debug-1)

--- a/R/get.R
+++ b/R/get.R
@@ -676,14 +676,14 @@ getProfiles <- function(index, destdir=argoDefaultDestdir(), age=argoDefaultProf
             # Get file again if it is
             #download2 <- which(!(timeUTC < dateUpdate)) # FIXME can turn this to ! if check to work
             download2 <- which(timeUTC < dateUpdate)
-            argoFloatsDebug(debug, "In age= ", age, ", files numbered" ,download1, " did not exist and are not skipped during downloading. \n")
-            argoFloatsDebug(debug, "In age= ", age, ", files numbered" ,download2, " did exist and had date older than the date_update. They are not skipped during downloading. \n")
+            argoFloatsDebug(debug, "In age= ", age, ", files " ,paste0(fileNames[download1], collapse=","), " did not exist and are not skipped during downloading. \n")
+            argoFloatsDebug(debug, "In age= ", age, ", files " ,paste0(fileNames[download2], collapse=","), " did exist and had date older than the date_update. They are not skipped during downloading. \n")
             SKIP1 <- which(!(seq_along(fileNames) %in% download1))
             SKIP2 <- which(!(seq_along(fileNames[keep]) %in% download2))
             skipDownload <<- rep(FALSE, length(fileNames))
             skipDownload[SKIP1] <<- TRUE
             skipDownload[SKIP2] <<- TRUE
-            argoFloatsDebug(debug, "Files numbered ", skipDownload, " are being skipped during download. \n")
+            argoFloatsDebug(debug, "Files ", paste0(fileNames[skipDownload], collapse=","), " are being skipped during download. \n")
         }
         file <- downloadWithRetries(urls, destdir=destdir, destfile=basename(urls),
             quiet=quiet, age=age, async=TRUE, debug=debug-1)

--- a/man/getProfiles.Rd
+++ b/man/getProfiles.Rd
@@ -33,9 +33,9 @@ File clutter is reduced by creating a top-level directory called
 If the file to be downloaded from the server already exists locally,
 and was created is less than age days in the past, it will not be downloaded.
 The default is one year. Setting age=0 will force a download.
-Option 2) "latest" if the file doesn't exist or the time it was
-created is older than the date_update in the index file, it will be
-downloaded. Otherwise it will not.}
+Option 2) "latest" meaning the file will only be downloaded if
+A) the file doesn't exist or B) the file does exist and the time
+it was created is older than the date_update in the index file}
 
 \item{retries}{integer telling how many times to retry a download,
 if the first attempt fails.}

--- a/man/getProfiles.Rd
+++ b/man/getProfiles.Rd
@@ -29,10 +29,13 @@ File clutter is reduced by creating a top-level directory called
 \code{data}, with subdirectories for various file types; see
 \dQuote{Examples}.}
 
-\item{age}{a numerical value indicating a time interval, in days.  If the file
-to be downloaded from the server already exists locally, and was created
-is less than \code{age} days in the past, it will not be downloaded.  The default,
-\code{\link[=argoDefaultProfileAge]{argoDefaultProfileAge()}}, is one year.  Setting \code{age=0} will force a download.}
+\item{age}{Option 1) a numerical value indicating a time interval, in days.
+If the file to be downloaded from the server already exists locally,
+and was created is less than age days in the past, it will not be downloaded.
+The default is one year. Setting age=0 will force a download.
+Option 2) "latest" if the file doesn't exist or the time it was
+created is older than the date_update in the index file, it will be
+downloaded. Otherwise it will not.}
 
 \item{retries}{integer telling how many times to retry a download,
 if the first attempt fails.}


### PR DESCRIPTION
This pull request is for issue 558, which was to develop an `age="latest"` argument for `getProfiles`. 

The way I approached this was if `getProfiles(age="latest")`, files were downloaded if:

1.  the file doesn't already  OR
2. The file does exist and the date it was created is OLDER than the `date_update` in the `index` 

Otherwise they were skipped.

`skipDownload` (already defined in `downLoadedWithRetries()` ) is then assigned to be anything that is not downloaded based on the two cases above. Documentation and debugging has also been update to indicate the changes as well.

Please note that when doing a "Check", I do receive 1 ERROR and 1 WARNING shown below.  This is not specific to this branch. I also get the same result with the `develop` branch and this has happened since updating my RStudio (at least when I started noticing it). 

![Screen Shot 2022-05-25 at 2 53 28 PM](https://user-images.githubusercontent.com/58750538/170330678-7cd82634-5d0b-48d0-a5e0-6d319e6d31b6.png)


